### PR TITLE
emoji: Remove duplicate results

### DIFF
--- a/plugins/emoji/__init__.py
+++ b/plugins/emoji/__init__.py
@@ -135,7 +135,7 @@ def handleQuery(query) -> list:
                     query_str, list(label_to_emoji_tuple.keys()), limit=30
                 )
                 matched_emojis = list(
-                    dict([label_to_emoji_tuple[label] for label, _ in matched]).items()
+                    dict([label_to_emoji_tuple[label] for label, *_ in matched]).items()
                 )
                 results.extend(
                     [get_emoji_as_item(emoji_tuple) for emoji_tuple in matched_emojis]

--- a/plugins/emoji/__init__.py
+++ b/plugins/emoji/__init__.py
@@ -134,9 +134,12 @@ def handleQuery(query) -> list:
                 matched = process.extract(
                     query_str, list(label_to_emoji_tuple.keys()), limit=30
                 )
-                for m in [elem[0] for elem in matched]:
-                    emoji_tuple = label_to_emoji_tuple[m]
-                    results.append(get_emoji_as_item(emoji_tuple))
+                matched_emojis = list(
+                    dict([label_to_emoji_tuple[label] for label, _ in matched]).items()
+                )
+                results.extend(
+                    [get_emoji_as_item(emoji_tuple) for emoji_tuple in matched_emojis]
+                )
 
         except Exception:  # user to report error
             if dev_mode:  # let exceptions fly!


### PR DESCRIPTION
If an emoji is matched by more than one label, it can show up more than once in the results.

This fixes the issue by removing emoji tuples having the same emoji before adding them to the results.