### PR TITLE
emoji: Remove newline from copied text

### DIFF
--- a/plugins/emoji/__init__.py
+++ b/plugins/emoji/__init__.py
@@ -89,7 +89,7 @@ def update_stats(emoji: str):
 
 def copy_emoji(emoji: str):
     update_stats(emoji)
-    subprocess.run(f"echo {emoji} | xclip -selection clipboard", shell=True)
+    subprocess.run(f"echo {emoji} | xclip -rmlastnl -selection clipboard", shell=True)
 
 
 def initialize():


### PR DESCRIPTION
Added the `-rmlastnl` flag to `xclip` so that the copied text is just the emoji and not the emoji followed by a newline.

manual info:
```
-r, -rmlastnl
      when the last character of the selection is a newline  character,  remove  it.
      Newline  characters  that  are not the last character in the selection are not
      affected. If the selection does not end with a newline character, this  option
      has  no  effect. This option is useful for copying one-line output of programs
      like pwd to the clipboard to paste it again into the  command  prompt  without
      executing the line immideately due to the newline character pwd appends.
```