### PR TITLE
Fix py_deps issue on emoji plugin

### DIFF
--- a/plugins/emoji/__init__.py
+++ b/plugins/emoji/__init__.py
@@ -20,7 +20,7 @@ __homepage__ = (
     "https://github.com/bergercookie/awesome-albert-plugins/blob/master/plugins/emoji"
 )
 __exec_deps__ = ["xclip"]
-__py_deps__ = ["em-keyboard"]
+__py_deps__ = ["em"]
 
 icon_path = str(Path(__file__).parent / "emoji.png")
 


### PR DESCRIPTION
Change `__py__deps` from `em-keyboard` to `em` in order to fix an issue where the plugin is not loaded even if all dependencies are installed.